### PR TITLE
progress bar width fixed

### DIFF
--- a/src/stories/StoryContainer.tsx
+++ b/src/stories/StoryContainer.tsx
@@ -138,7 +138,13 @@ const StoryContainer = (props: StoryContainerProps) => {
 					</View>
 				</View>
 
-				<View style={styles.progressView}>
+				<View style={{
+            				flex: 1,
+            				width: props?.progressView?.width ?? Dimensions.get('window').width, // Important
+            				position: 'absolute',
+            				flexDirection: 'row',
+            				backgroundColor: props?.progressView?.backgroundColor ?? TINT_GRAY,
+          		}}>
 					<ProgressView
 						enableProgress={
 							props.enableProgress != undefined

--- a/src/utils/interfaceHelper.tsx
+++ b/src/utils/interfaceHelper.tsx
@@ -29,7 +29,7 @@ export interface StoryContainerProps extends CommonProps {
 
     replyView?: ReplyProps | undefined 
     footerComponent?: FunctionComponentElement<CommonProps> | undefined 
-
+    progressView?: { width: number; backgroundColor: string } | undefined
     onComplete: Function,  
 }
 


### PR DESCRIPTION
This PR fixed progress bar width
progress bar width goes out of the container 


<img width="306" alt="Screenshot 2022-08-24 at 4 51 27 PM" src="https://user-images.githubusercontent.com/26919832/186407439-8b8732ee-97d2-4d09-beca-fe01ef6c8292.png">

It will look like this


<img width="295" alt="Screenshot 2022-08-24 at 4 51 01 PM" src="https://user-images.githubusercontent.com/26919832/186408448-4b65c731-4e89-4428-8ddf-54add76e02fb.png">


```
<StoryContainer
          .....
          progressView={{
            width: 340,
          }}
/>
```

